### PR TITLE
Update setup_linux.py

### DIFF
--- a/lib/nms/setup_linux.py
+++ b/lib/nms/setup_linux.py
@@ -111,7 +111,7 @@ ext_modules = [
     Extension(
         "cpu_nms",
         ["cpu_nms.pyx"],
-        extra_compile_args={'gcc': ["-Wno-cpp", "-Wno-unused-function"]},
+        extra_compile_args={'gcc': ["-Wno-cpp", "-Wno-unused-function", "-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION"]},
         include_dirs = [numpy_include]
     ),
     Extension('gpu_nms',
@@ -123,8 +123,8 @@ ext_modules = [
         # this syntax is specific to this build system
         # we're only going to use certain compiler args with nvcc and not with
         # gcc the implementation of this trick is in customize_compiler() below
-        extra_compile_args={'gcc': ["-Wno-unused-function"],
-                            'nvcc': ['-arch=sm_35',
+        extra_compile_args={'gcc': ["-Wno-unused-function", "-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION"],
+                            'nvcc': ['-arch=sm_75',
                                      '--ptxas-options=-v',
                                      '-c',
                                      '--compiler-options',


### PR DESCRIPTION
#10 
- [x] Added the compiler argument `-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION` for the gcc compiler in both cpu_nms and gpu_nms extensions. This argument defines a preprocessor macro to disable deprecated API in NumPy, targeting version 1.7 API. This can help ensure compatibility with newer NumPy versions and avoid warnings related to deprecated features
- [x] Changed this to `-arch=sm_75`. This change updates the CUDA compute capability from 3.5 to 7.5. The newer compute capability supports more recent CUDA features and optimizations for newer GPU architectures (e.g., NVIDIA Turing architecture).

Tested in Google colab with T4 GPU
![image](https://github.com/ostadabbas/Infant-Pose-Estimation/assets/56753150/c67d0c7a-0ad4-405a-b916-4132a4e206dc)
